### PR TITLE
Add support for Python version; update anaconda_base_url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,13 @@
 # [*download_timeout*]
 #   Defaults to 30 minutes.  The time to wait for the installer to download
 #
+# [*py_version*]
+#   Specify Python version for the root env.  Default is Python3.
+#
+# [*version*]
+#   Specify Anaconda version. Miniconda (light_install) supports 'latest'.  
+#   Full Anaconda install requires specific version number.
+#
 # === Examples
 #
 #  include conda
@@ -33,7 +40,8 @@ class conda (
     $light_install    = true,
     $download_timeout = 1800,
     $channel          = undef,
-    $version          = '2.5.0',
+    $py_version       = '3',
+    $version          = '4.3.1',
 ) {
     include conda::install
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 #
 # Internal class for setting up parameters
 class conda::params {
-
+ 
     $install_dir = $::kernel ? {
         'windows'     => 'C:\Anaconda',
         /(L|l)inux/   => '/opt/anaconda',
@@ -16,23 +16,21 @@ class conda::params {
     }
 
     $base_url = 'http://repo.continuum.io/miniconda'
-    #$base_url = 'http://local-package-server/Files'
 
     # Some versions of puppet report uppercase Linux
     $installer = $::kernel ? {
-        /(L|l)inux/   => 'Miniconda-latest-Linux-x86_64.sh',
-        'windows'     => 'Miniconda-latest-Windows-x86_64.exe',
+        /(L|l)inux/   => "Miniconda${conda::py_version}-${conda::version}-Linux-x86_64.sh",
+        'windows'     => "Miniconda${conda::py_version}-${conda::version}-Windows-x86_64.exe",
         default       => 'FAIL'
     }
     $url = "${base_url}/${installer}"
 
     # Anaconda URLS
-    $anaconda_base_url = 'http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com'
-    #$anaconda_base_url = 'http://local-package-server/Files'
+    $anaconda_base_url = 'http://repo.continuum.io/archive'
 
     $anaconda_installer = $::kernel ? {
-        /(L|l)inux/ => "Anaconda-${conda::version}-Linux-x86_64.sh",
-        'windows'   => "Anaconda-${conda::version}-Windows-x86_64.exe",
+        /(L|l)inux/ => "Anaconda${conda::py_version}-${conda::version}-Linux-x86_64.sh",
+        'windows'   => "Anaconda${conda::py_version}-${conda::version}-Windows-x86_64.exe",
         default     => 'FAIL'
     }
 


### PR DESCRIPTION
This should allow support for Python2 or 3 versions of Anaconda (or Miniconda)